### PR TITLE
Some junk wrt. tiles

### DIFF
--- a/mappings/net/minecraft/level/Level.mapping
+++ b/mappings/net/minecraft/level/Level.mapping
@@ -31,6 +31,18 @@ CLASS fd net/minecraft/level/Level
 	METHOD a getPlayerByName (Ljava/lang/String;)Lgs;
 	METHOD a addParticle (Ljava/lang/String;DDDDDD)V
 	METHOD a getClosestPlayerTo (Lsn;D)Lgs;
+	METHOD a createExplosion (Lsn;DDDF)Lqx;
+		ARG 1 cause
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z
+		ARG 8 power
+	METHOD a createExplosion (Lsn;DDDFZ)Lqx;
+		ARG 1 cause
+		ARG 2 x
+		ARG 4 y
+		ARG 6 z
+		ARG 8 power
 	METHOD a playSound (Lsn;Ljava/lang/String;FF)V
 	METHOD a (ZLyb;)V
 		ARG 2 listener

--- a/mappings/net/minecraft/network/PacketHandler.mapping
+++ b/mappings/net/minecraft/network/PacketHandler.mapping
@@ -7,6 +7,8 @@ CLASS ti net/minecraft/network/PacketHandler
 	METHOD a handleCloseContainer (Lmn;)V
 		ARG 1 packet
 	METHOD a handleHandSwing (Lnm;)V
+	METHOD a handleExplosion (Lrm;)V
+		ARG 1 packet
 	METHOD a handleEntitySpawn (Lso;)V
 		ARG 1 packet
 	METHOD a handleUpdateRain (Lvw;)V

--- a/mappings/net/minecraft/packet/CreateExplosionS2CPacket.mapping
+++ b/mappings/net/minecraft/packet/CreateExplosionS2CPacket.mapping
@@ -1,0 +1,1 @@
+CLASS rm net/minecraft/packet/CreateExplosionS2CPacket

--- a/mappings/net/minecraft/packet/Id60Packet.mapping
+++ b/mappings/net/minecraft/packet/Id60Packet.mapping
@@ -1,1 +1,0 @@
-CLASS rm net/minecraft/packet/Id60Packet

--- a/mappings/net/minecraft/sortme/Explosion.mapping
+++ b/mappings/net/minecraft/sortme/Explosion.mapping
@@ -1,0 +1,20 @@
+CLASS qx net/minecraft/sortme/Explosion
+	FIELD a causeFires Z
+	FIELD b x D
+	FIELD c y D
+	FIELD d z D
+	FIELD e cause Lsn;
+	FIELD f power F
+	FIELD g damagedTiles Ljava/util/Set;
+	FIELD h random Ljava/util/Random;
+	FIELD i level Lfd;
+	METHOD <init> (Lfd;Lsn;DDDF)V
+		ARG 1 level
+		ARG 2 cause
+		ARG 3 x
+		ARG 5 y
+		ARG 7 z
+		ARG 9 power
+	METHOD a kaboomPhase1 ()V
+	METHOD a kaboomPhase2 (Z)V
+		ARG 1 showParticles

--- a/mappings/net/minecraft/sortme/ExplosionEntry.mapping
+++ b/mappings/net/minecraft/sortme/ExplosionEntry.mapping
@@ -1,0 +1,10 @@
+CLASS wf net/minecraft/sortme/ExplosionEntry
+	FIELD a x I
+	FIELD b y I
+	FIELD c z I
+	METHOD <init> (III)V
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+	METHOD equals (Ljava/lang/Object;)Z
+		ARG 1 other

--- a/mappings/net/minecraft/tile/Bed.mapping
+++ b/mappings/net/minecraft/tile/Bed.mapping
@@ -1,2 +1,23 @@
 CLASS ve net/minecraft/tile/Bed
+	FIELD a SPAWN_OFFSETS [[I
+	METHOD <init> (I)V
+		ARG 1 id
+	METHOD a setOccupied (Lfd;IIIZ)V
+		ARG 0 level
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 isOccupied
+	METHOD d orientationOnly (I)I
+		ARG 0 meta
+	METHOD e isFoot (I)Z
+		ARG 0 meta
+	METHOD f isOccupied (I)Z
+		ARG 0 meta
 	METHOD f findWakeUpPosition (Lfd;IIII)Lbr;
+		ARG 0 level
+		ARG 1 x
+		ARG 2 y
+		ARG 3 z
+		ARG 4 tries
+	METHOD r resetBoundingBox ()V

--- a/mappings/net/minecraft/tile/Block36.mapping
+++ b/mappings/net/minecraft/tile/Block36.mapping
@@ -1,0 +1,3 @@
+CLASS ut net/minecraft/tile/Block36
+	METHOD <init> (I)V
+		ARG 1 id

--- a/mappings/net/minecraft/tile/Bookshelf.mapping
+++ b/mappings/net/minecraft/tile/Bookshelf.mapping
@@ -1,1 +1,4 @@
 CLASS hb net/minecraft/tile/Bookshelf
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 texUVStart

--- a/mappings/net/minecraft/tile/Button.mapping
+++ b/mappings/net/minecraft/tile/Button.mapping
@@ -1,1 +1,4 @@
 CLASS oi net/minecraft/tile/Button
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 texUVStart

--- a/mappings/net/minecraft/tile/Cake.mapping
+++ b/mappings/net/minecraft/tile/Cake.mapping
@@ -1,1 +1,4 @@
 CLASS um net/minecraft/tile/Cake
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 texUVStart

--- a/mappings/net/minecraft/tile/Ladder.mapping
+++ b/mappings/net/minecraft/tile/Ladder.mapping
@@ -1,1 +1,4 @@
 CLASS dp net/minecraft/tile/Ladder
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 tileUVStart

--- a/mappings/net/minecraft/tile/Ladder.mapping
+++ b/mappings/net/minecraft/tile/Ladder.mapping
@@ -1,4 +1,4 @@
 CLASS dp net/minecraft/tile/Ladder
 	METHOD <init> (II)V
 		ARG 1 id
-		ARG 2 tileUVStart
+		ARG 2 texUVStart

--- a/mappings/net/minecraft/tile/RedstoneOre.mapping
+++ b/mappings/net/minecraft/tile/RedstoneOre.mapping
@@ -1,1 +1,5 @@
 CLASS bs net/minecraft/tile/RedstoneOre
+	FIELD a isLit Z
+	METHOD <init> (IIZ)V
+		ARG 3 isLit
+	METHOD h onTouch (Lfd;III)V

--- a/mappings/net/minecraft/tile/Snow.mapping
+++ b/mappings/net/minecraft/tile/Snow.mapping
@@ -1,1 +1,4 @@
 CLASS jr net/minecraft/tile/Snow
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 texUVStart

--- a/mappings/net/minecraft/tile/SnowBlock.mapping
+++ b/mappings/net/minecraft/tile/SnowBlock.mapping
@@ -1,1 +1,4 @@
 CLASS ac net/minecraft/tile/SnowBlock
+	METHOD <init> (II)V
+		ARG 1 id
+		ARG 2 texUVStart

--- a/mappings/net/minecraft/tile/Tile.mapping
+++ b/mappings/net/minecraft/tile/Tile.mapping
@@ -55,6 +55,7 @@ CLASS uu net/minecraft/tile/Tile
 	FIELD aa PISTON Luu;
 	FIELD ab PISTON_HEAD Lh;
 	FIELD ac WOOL Luu;
+	FIELD ad BLOCK_36 Lut;
 	FIELD ae DANDELION Lwb;
 	FIELD af ROSE Lwb;
 	FIELD ag MUSHROOM_1 Lwb;
@@ -111,8 +112,19 @@ CLASS uu net/minecraft/tile/Tile
 	FIELD x STONEBRICK Luu;
 	FIELD y WOOD Luu;
 	FIELD z SAPLING Luu;
+	METHOD <init> (IILln;)V
+		ARG 1 id
+		ARG 2 texUVStart
+		ARG 3 material
+	METHOD <init> (ILln;)V
+		ARG 1 id
+		ARG 2 material
+	METHOD a setBoundingBox (FFFFFF)V
 	METHOD a getDropId (ILjava/util/Random;)I
+		ARG 1 meta
+		ARG 2 random
 	METHOD a sounds (Lct;)Luu;
+		ARG 1 sounds
 	METHOD a canPlaceAt (Lfd;III)Z
 		ARG 1 level
 		ARG 2 x
@@ -125,11 +137,28 @@ CLASS uu net/minecraft/tile/Tile
 		ARG 4 z
 		ARG 5 meta
 	METHOD a beforeDestroyedByExplosion (Lfd;IIIIF)V
+		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+		ARG 5 meta
+		ARG 6 dropChance
 	METHOD a onTileAction (Lfd;IIIII)V
 		ARG 2 x
 		ARG 3 y
 		ARG 4 z
 		ARG 5 blockMeta
+	METHOD a (Lfd;IIILgs;)Z
+		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+		ARG 5 player
+	METHOD a (Lfd;IIILiz;)V
+		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
 	METHOD a onScheduledTick (Lfd;IIILjava/util/Random;)V
 		ARG 2 x
 		ARG 3 y
@@ -141,14 +170,51 @@ CLASS uu net/minecraft/tile/Tile
 	METHOD a getDropCount (Ljava/util/Random;)I
 	METHOD b onTileRemoved (Lfd;III)V
 		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD b (Lfd;IIII)V
+		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
 	METHOD b activate (Lfd;IIILgs;)V
+		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
 	METHOD b randomDisplayTick (Lfd;IIILjava/util/Random;)V
 	METHOD c isFullOpaque ()Z
+	METHOD c (Lfd;III)V
+		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
 	METHOD d isFullCube ()Z
 	METHOD d onDestroyedByExplosion (Lfd;III)V
 	METHOD e getTickrate ()I
 	METHOD e getCollisionShape (Lfd;III)Leq;
+		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
 	METHOD e onPlaced (Lfd;IIII)V
+		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+		ARG 5 facing
 	METHOD f emitsRedstonePower ()Z
 	METHOD f getOutlineShape (Lfd;III)Leq;
+		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+	METHOD g drop (Lfd;IIII)V
+		ARG 1 level
+		ARG 2 x
+		ARG 3 y
+		ARG 4 z
+		ARG 5 meta
+	METHOD h getPistonPushMode ()I
 	METHOD n getName ()Ljava/lang/String;

--- a/mappings/net/minecraft/tile/material/Material.mapping
+++ b/mappings/net/minecraft/tile/material/Material.mapping
@@ -4,6 +4,7 @@ CLASS ln net/minecraft/tile/material/Material
 	FIELD D burnable Z
 	FIELD E replaceable Z
 	FIELD G requiresTool Z
+	FIELD H pistonPushMode I
 	FIELD a AIR Lln;
 	FIELD b ORGANIC Lln;
 	FIELD c DIRT Lln;
@@ -18,17 +19,27 @@ CLASS ln net/minecraft/tile/material/Material
 	FIELD l WOOL Lln;
 	FIELD m FIRE Lln;
 	FIELD n SAND Lln;
+	FIELD o DOODADS Lln;
 	FIELD p GLASS Lln;
+	FIELD q TNT Lln;
+	FIELD r UNUSED_LOL Lln;
 	FIELD s ICE Lln;
+	FIELD t SNOW Lln;
+	FIELD u SNOW_BLOCK Lln;
 	FIELD v CACTUS Lln;
 	FIELD w CLAY Lln;
+	FIELD x PUMPKIN Lln;
+	FIELD y PORTAL Lln;
 	FIELD z CAKE Lln;
 	METHOD a isSolid ()Z
 	METHOD c blocksMovement ()Z
 	METHOD d isLiquid ()Z
 	METHOD e isBurnable ()Z
+	METHOD f replaceable ()Lln;
 	METHOD g isReplaceable ()Z
 	METHOD i doesRequireTool ()Z
-	METHOD k lightPassesThrough ()Lln;
+	METHOD j getPistonPushMode ()I
+	METHOD k breaksWhenPushed ()Lln;
+	METHOD l unpushable ()Lln;
 	METHOD n requiresTool ()Lln;
 	METHOD o burnable ()Lln;

--- a/mappings/net/minecraft/tile/material/PortalMaterial.mapping
+++ b/mappings/net/minecraft/tile/material/PortalMaterial.mapping
@@ -1,0 +1,1 @@
+CLASS ou net/minecraft/tile/material/PortalMaterial

--- a/mappings/xa.mapping
+++ b/mappings/xa.mapping
@@ -1,0 +1,2 @@
+CLASS xa
+	METHOD f bedsDontExplode ()Z


### PR DESCRIPTION
* `ut` -> `Block36`
  * This is... the tile with ID 36. Seems like a cop-out name, but hear me out:
  * The equivalent in modern MC is `minecraft:piston_extension`.
  * Before string IDs, it's been colloquially known in redstone circles as "block 36" for about as long as it's been around.
  * Just search up youtube for "block 36", there are tons of classic minecraft videos about it.

* `Material.lightPassesThrough` -> `breaksWhenPushed`
  * Doesn't have anything to do with lighting but has everything to do with piston code, if enigma Show Calls can be trusted

* Explosions... threw these under `sortme`
  * Not sure about `ExplosionEntry`
* Bed internals
* Piston push modes
* The missing `Material`s, including `UNUSED_LOL`
  * Just did a quick Show Calls, most of these had only 1 or 2 usages
  * is `DOODADS` for the "catchall ladders and redstone" one cursed enough? :)
* A handful of low-hanging fruit parameter names just in case the diff was too readable (I need to stop doing this)