### PR TITLE
Networking fun 2: Electric Boolago

### DIFF
--- a/mappings/net/minecraft/network/PacketHandler.mapping
+++ b/mappings/net/minecraft/network/PacketHandler.mapping
@@ -1,5 +1,8 @@
 CLASS net/minecraft/class_240 net/minecraft/network/PacketHandler
-	METHOD method_1469 (Lnet/minecraft/class_161;)V
+	METHOD method_1427 handleCloseContainer (Lnet/minecraft/class_276;)V
+		ARG 1 packet
+	METHOD method_1428 handleHandSwing (Lnet/minecraft/class_305;)V
+	METHOD method_1431 onChatMessage (Lnet/minecraft/class_340;)V
 		ARG 1 packet
 	METHOD method_1438 (Lnet/minecraft/class_435;)V
 		ARG 1 packet
@@ -8,14 +11,11 @@ CLASS net/minecraft/class_240 net/minecraft/network/PacketHandler
 		ARG 1 packet
 	METHOD method_1446 handleOpenScreen (Lnet/minecraft/class_201;)V
 		ARG 1 packet
-	METHOD method_1427 handleCloseContainer (Lnet/minecraft/class_276;)V
-		ARG 1 packet
-	METHOD method_1428 handleHandSwing (Lnet/minecraft/class_305;)V
-	METHOD method_1431 onChatMessage (Lnet/minecraft/class_340;)V
-		ARG 1 packet
 	METHOD method_1458 handleExplosion (Lnet/minecraft/class_382;)V
 		ARG 1 packet
 	METHOD method_1462 handleEntitySpawn (Lnet/minecraft/class_414;)V
 		ARG 1 packet
 	METHOD method_1467 handleUpdateRain (Lnet/minecraft/class_440;)V
+	METHOD method_1469 (Lnet/minecraft/class_161;)V
+		ARG 1 packet
 	METHOD method_1470 handle (Lnet/minecraft/class_169;)V

--- a/mappings/net/minecraft/network/PacketHandler.mapping
+++ b/mappings/net/minecraft/network/PacketHandler.mapping
@@ -1,5 +1,5 @@
 CLASS net/minecraft/class_240 net/minecraft/network/PacketHandler
-	METHOD method_1427 handleCloseContainer (Lnet/minecraft/class_276;)V
+	METHOD method_1427 handleContainerClose (Lnet/minecraft/class_276;)V
 		ARG 1 packet
 	METHOD method_1428 handleHandSwing (Lnet/minecraft/class_305;)V
 	METHOD method_1431 handleChatMessage (Lnet/minecraft/class_340;)V
@@ -9,7 +9,7 @@ CLASS net/minecraft/class_240 net/minecraft/network/PacketHandler
 	METHOD method_1440 handlePlayerHealthUpdate (Lnet/minecraft/class_36;)V
 	METHOD method_1444 handleLevelTimeUpdate (Lnet/minecraft/class_156;)V
 		ARG 1 packet
-	METHOD method_1446 handleOpenScreen (Lnet/minecraft/class_201;)V
+	METHOD method_1446 handleScreenOpen (Lnet/minecraft/class_201;)V
 		ARG 1 packet
 	METHOD method_1458 handleExplosion (Lnet/minecraft/class_382;)V
 		ARG 1 packet
@@ -19,3 +19,4 @@ CLASS net/minecraft/class_240 net/minecraft/network/PacketHandler
 	METHOD method_1469 (Lnet/minecraft/class_161;)V
 		ARG 1 packet
 	METHOD method_1470 handle (Lnet/minecraft/class_169;)V
+	METHOD method_1472 handleHandshake (Lnet/minecraft/class_118;)V

--- a/mappings/net/minecraft/network/PacketHandler.mapping
+++ b/mappings/net/minecraft/network/PacketHandler.mapping
@@ -2,7 +2,7 @@ CLASS net/minecraft/class_240 net/minecraft/network/PacketHandler
 	METHOD method_1427 handleCloseContainer (Lnet/minecraft/class_276;)V
 		ARG 1 packet
 	METHOD method_1428 handleHandSwing (Lnet/minecraft/class_305;)V
-	METHOD method_1431 onChatMessage (Lnet/minecraft/class_340;)V
+	METHOD method_1431 handleChatMessage (Lnet/minecraft/class_340;)V
 		ARG 1 packet
 	METHOD method_1438 (Lnet/minecraft/class_435;)V
 		ARG 1 packet

--- a/mappings/net/minecraft/packet/CloseContainerS2CPacket.mapping
+++ b/mappings/net/minecraft/packet/CloseContainerS2CPacket.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_276 net/minecraft/packet/CloseContainerS2CPacket

--- a/mappings/net/minecraft/packet/CreateExplosionS2CPacket.mapping
+++ b/mappings/net/minecraft/packet/CreateExplosionS2CPacket.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_382 net/minecraft/packet/CreateExplosionS2CPacket

--- a/mappings/net/minecraft/packet/HandSwingC2SPacket.mapping
+++ b/mappings/net/minecraft/packet/HandSwingC2SPacket.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_305 net/minecraft/packet/HandSwingC2SPacket

--- a/mappings/net/minecraft/packet/Id1Packet.mapping
+++ b/mappings/net/minecraft/packet/Id1Packet.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_118 net/minecraft/packet/Id1Packet

--- a/mappings/net/minecraft/packet/Id2Packet.mapping
+++ b/mappings/net/minecraft/packet/Id2Packet.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_281 net/minecraft/packet/Id2Packet
-	FIELD field_1130 serverId Ljava/lang/String;

--- a/mappings/net/minecraft/packet/LevelTimeUpdateS2CPacket.mapping
+++ b/mappings/net/minecraft/packet/LevelTimeUpdateS2CPacket.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_156 net/minecraft/packet/LevelTimeUpdateS2CPacket
-	FIELD field_558 levelTime J

--- a/mappings/net/minecraft/packet/OpenScreenS2CPacket.mapping
+++ b/mappings/net/minecraft/packet/OpenScreenS2CPacket.mapping
@@ -1,3 +1,0 @@
-CLASS net/minecraft/class_201 net/minecraft/packet/OpenScreenS2CPacket
-	FIELD field_741 containerId I
-	FIELD field_742 screenId I

--- a/mappings/net/minecraft/packet/SendChatMessageC2SPacket.mapping
+++ b/mappings/net/minecraft/packet/SendChatMessageC2SPacket.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_340 net/minecraft/packet/SendChatMessageC2SPacket
-	FIELD field_1270 message Ljava/lang/String;

--- a/mappings/net/minecraft/packet/UpdatePlayerHealthS2CPacket.mapping
+++ b/mappings/net/minecraft/packet/UpdatePlayerHealthS2CPacket.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_36 net/minecraft/packet/UpdatePlayerHealthS2CPacket
-	FIELD field_158 health I

--- a/mappings/net/minecraft/packet/UpdateRainS2CPacket.mapping
+++ b/mappings/net/minecraft/packet/UpdateRainS2CPacket.mapping
@@ -1,1 +1,0 @@
-CLASS net/minecraft/class_440 net/minecraft/packet/UpdateRainS2CPacket

--- a/mappings/net/minecraft/packet/handshake/HandshakeC2S.mapping
+++ b/mappings/net/minecraft/packet/handshake/HandshakeC2S.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_118 net/minecraft/packet/handshake/HandshakeC2S
+	FIELD field_1209 protocolVersion I

--- a/mappings/net/minecraft/packet/handshaking/HandshakeC2S.mapping
+++ b/mappings/net/minecraft/packet/handshaking/HandshakeC2S.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_118 net/minecraft/packet/handshaking/HandshakeC2S
+	FIELD field_1209 protocolVersion I

--- a/mappings/net/minecraft/packet/handshaking/HandshakeC2S.mapping
+++ b/mappings/net/minecraft/packet/handshaking/HandshakeC2S.mapping
@@ -1,2 +1,0 @@
-CLASS net/minecraft/class_118 net/minecraft/packet/handshaking/HandshakeC2S
-	FIELD field_1209 protocolVersion I

--- a/mappings/net/minecraft/packet/login/ClientUsernameC2S.mapping
+++ b/mappings/net/minecraft/packet/login/ClientUsernameC2S.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_281 net/minecraft/packet/login/ClientUsernameC2S
+	FIELD field_1130 serverId Ljava/lang/String;

--- a/mappings/net/minecraft/packet/play/CloseContainerS2C.mapping
+++ b/mappings/net/minecraft/packet/play/CloseContainerS2C.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_276 net/minecraft/packet/play/CloseContainerS2C

--- a/mappings/net/minecraft/packet/play/CreateExplosionS2C.mapping
+++ b/mappings/net/minecraft/packet/play/CreateExplosionS2C.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_382 net/minecraft/packet/play/CreateExplosionS2C

--- a/mappings/net/minecraft/packet/play/EntitySpawnS2C.mapping
+++ b/mappings/net/minecraft/packet/play/EntitySpawnS2C.mapping
@@ -1,4 +1,4 @@
-CLASS net/minecraft/class_414 net/minecraft/packet/EntitySpawnS2CPacket
+CLASS net/minecraft/class_414 net/minecraft/packet/play/EntitySpawnS2C
 	FIELD field_1664 x I
 	FIELD field_1665 y I
 	FIELD field_1666 z I

--- a/mappings/net/minecraft/packet/play/HandSwingC2S.mapping
+++ b/mappings/net/minecraft/packet/play/HandSwingC2S.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_305 net/minecraft/packet/play/HandSwingC2S

--- a/mappings/net/minecraft/packet/play/LevelTimeUpdateS2C.mapping
+++ b/mappings/net/minecraft/packet/play/LevelTimeUpdateS2C.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_156 net/minecraft/packet/play/LevelTimeUpdateS2C
+	FIELD field_558 levelTime J

--- a/mappings/net/minecraft/packet/play/OpenScreenS2C.mapping
+++ b/mappings/net/minecraft/packet/play/OpenScreenS2C.mapping
@@ -1,0 +1,3 @@
+CLASS net/minecraft/class_201 net/minecraft/packet/play/OpenScreenS2C
+	FIELD field_741 containerId I
+	FIELD field_742 screenId I

--- a/mappings/net/minecraft/packet/play/SendChatMessageC2S.mapping
+++ b/mappings/net/minecraft/packet/play/SendChatMessageC2S.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_340 net/minecraft/packet/play/SendChatMessageC2S
+	FIELD field_1270 message Ljava/lang/String;

--- a/mappings/net/minecraft/packet/play/UpdatePlayerHealthS2C.mapping
+++ b/mappings/net/minecraft/packet/play/UpdatePlayerHealthS2C.mapping
@@ -1,0 +1,2 @@
+CLASS net/minecraft/class_36 net/minecraft/packet/play/UpdatePlayerHealthS2C
+	FIELD field_158 health I

--- a/mappings/net/minecraft/packet/play/UpdateRainS2C.mapping
+++ b/mappings/net/minecraft/packet/play/UpdateRainS2C.mapping
@@ -1,0 +1,1 @@
+CLASS net/minecraft/class_440 net/minecraft/packet/play/UpdateRainS2C

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -1,0 +1,16 @@
+CLASS net/minecraft/server/MinecraftServer
+	CLASS class_643 ServerThread
+	CLASS class_645 ConsoleInputThread
+	CLASS class_646 MagicalTimingHelperThread
+	FIELD field_2837 logger Ljava/util/logging/Logger;
+	FIELD field_2839 pendingConnectionManager Lnet/minecraft/class_9;
+	FIELD field_2840 serverProperties Lnet/minecraft/class_391;
+	FIELD field_2848 onlineMode Z
+	FIELD field_2849 spawnAnimals Z
+	FIELD field_2850 allowPvp Z
+	FIELD field_2851 AllowFlight Z
+	METHOD main ([Ljava/lang/String;)V
+		ARG 0 args
+	METHOD method_2160 getFile (Ljava/lang/String;)Ljava/io/File;
+	METHOD method_2166 start ()Z
+	METHOD method_2167 logWarning (Ljava/lang/String;)V

--- a/mappings/net/minecraft/server/MinecraftServer.mapping
+++ b/mappings/net/minecraft/server/MinecraftServer.mapping
@@ -8,7 +8,7 @@ CLASS net/minecraft/server/MinecraftServer
 	FIELD field_2848 onlineMode Z
 	FIELD field_2849 spawnAnimals Z
 	FIELD field_2850 allowPvp Z
-	FIELD field_2851 AllowFlight Z
+	FIELD field_2851 allowFlight Z
 	METHOD main ([Ljava/lang/String;)V
 		ARG 0 args
 	METHOD method_2160 getFile (Ljava/lang/String;)Ljava/io/File;

--- a/mappings/net/minecraft/server/ServerProperties.mapping
+++ b/mappings/net/minecraft/server/ServerProperties.mapping
@@ -1,0 +1,18 @@
+CLASS net/minecraft/class_391 net/minecraft/server/ServerProperties
+	FIELD field_1519 logger Ljava/util/logging/Logger;
+	FIELD field_1520 properties Ljava/util/Properties;
+	FIELD field_1521 propertiesFIle Ljava/io/File;
+	METHOD method_1245 generate ()V
+	METHOD method_1246 getInteger (Ljava/lang/String;I)I
+		ARG 1 key
+		ARG 2 defaultValue
+	METHOD method_1247 getString (Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;
+		ARG 1 key
+		ARG 2 defaultValue
+	METHOD method_1248 getBoolean (Ljava/lang/String;Z)Z
+		ARG 1 key
+		ARG 2 defaultValue
+	METHOD method_1249 save ()V
+	METHOD method_1250 setBoolean (Ljava/lang/String;Z)V
+		ARG 1 key
+		ARG 2 value

--- a/mappings/net/minecraft/server/ServerProperties.mapping
+++ b/mappings/net/minecraft/server/ServerProperties.mapping
@@ -1,7 +1,7 @@
 CLASS net/minecraft/class_391 net/minecraft/server/ServerProperties
 	FIELD field_1519 logger Ljava/util/logging/Logger;
 	FIELD field_1520 properties Ljava/util/Properties;
-	FIELD field_1521 propertiesFIle Ljava/io/File;
+	FIELD field_1521 propertiesFile Ljava/io/File;
 	METHOD method_1245 generate ()V
 	METHOD method_1246 getInteger (Ljava/lang/String;I)I
 		ARG 1 key

--- a/mappings/net/minecraft/server/network/PendingConnection.mapping
+++ b/mappings/net/minecraft/server/network/PendingConnection.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_10 net/minecraft/server/network/PendingConnection
+	FIELD field_353 logger Ljava/util/logging/Logger;
+	FIELD field_354 playNetworkHandler Lnet/minecraft/class_117;
+	FIELD field_355 closed Z
+	FIELD field_356 random Ljava/util/Random;
+	FIELD field_357 minecraftServer Lnet/minecraft/server/MinecraftServer;
+	FIELD field_358 timePassed I
+	FIELD field_360 handshakePacket Lnet/minecraft/class_118;
+	METHOD method_414 completeOrTimeOut ()V
+	METHOD method_417 drop (Ljava/lang/String;)V
+	METHOD method_419 complete (Lnet/minecraft/class_118;)V

--- a/mappings/net/minecraft/server/network/PendingConnection.mapping
+++ b/mappings/net/minecraft/server/network/PendingConnection.mapping
@@ -2,9 +2,9 @@ CLASS net/minecraft/class_10 net/minecraft/server/network/PendingConnection
 	FIELD field_353 logger Ljava/util/logging/Logger;
 	FIELD field_354 playNetworkHandler Lnet/minecraft/class_117;
 	FIELD field_355 closed Z
-	FIELD field_356 random Ljava/util/Random;
+	FIELD field_356 rand Ljava/util/Random;
 	FIELD field_357 minecraftServer Lnet/minecraft/server/MinecraftServer;
-	FIELD field_358 timePassed I
+	FIELD field_358 timeElapsed I
 	FIELD field_360 handshakePacket Lnet/minecraft/class_118;
 	METHOD method_414 completeOrTimeOut ()V
 	METHOD method_417 drop (Ljava/lang/String;)V

--- a/mappings/net/minecraft/server/network/PendingConnectionManager.mapping
+++ b/mappings/net/minecraft/server/network/PendingConnectionManager.mapping
@@ -3,7 +3,7 @@ CLASS net/minecraft/class_9 net/minecraft/server/network/PendingConnectionManage
 	FIELD field_29 listening Z
 	FIELD field_30 minecraftServer Lnet/minecraft/server/MinecraftServer;
 	FIELD field_31 socket Ljava/net/ServerSocket;
-	FIELD field_32 listenThread Ljava/lang/Thread;
+	FIELD field_32 listeningThread Ljava/lang/Thread;
 	FIELD field_34 pendingConnections Ljava/util/ArrayList;
 	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Ljava/net/InetAddress;I)V
 		ARG 3 port

--- a/mappings/net/minecraft/server/network/PendingConnectionManager.mapping
+++ b/mappings/net/minecraft/server/network/PendingConnectionManager.mapping
@@ -1,0 +1,11 @@
+CLASS net/minecraft/class_9 net/minecraft/server/network/PendingConnectionManager
+	FIELD field_28 logger Ljava/util/logging/Logger;
+	FIELD field_29 listening Z
+	FIELD field_30 minecraftServer Lnet/minecraft/server/MinecraftServer;
+	FIELD field_31 socket Ljava/net/ServerSocket;
+	FIELD field_32 listenThread Ljava/lang/Thread;
+	FIELD field_34 pendingConnections Ljava/util/ArrayList;
+	METHOD <init> (Lnet/minecraft/server/MinecraftServer;Ljava/net/InetAddress;I)V
+		ARG 3 port
+	METHOD method_34 handlePendingConnections ()V
+	METHOD method_37 add (Lnet/minecraft/class_10;)V


### PR DESCRIPTION
One force-push later and this works properly.
Old description:
- Drop the packet suffix on packets
- Move packets to a package based on the "game state" as roughly described on wiki.vg
- Map classes involved with the initial player connection handling
- ServerProperties class
- Various other stuff in MinecraftServer
